### PR TITLE
Ignore ember-cli-babel@7 on Greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["eslint-plugin-prettier"]
+  "ignore": ["eslint-plugin-prettier", "ember-cli-babel"]
 }


### PR DESCRIPTION
ember-cli-babel@7 drops support of ember-cli < 2.13. It's not worthy to drop the support coverage for Babel 7